### PR TITLE
Fix realloc call by taking char* size into account

### DIFF
--- a/Chapter 7/program7_14.c
+++ b/Chapter 7/program7_14.c
@@ -28,7 +28,7 @@ int main(void)
     {
       capacity += capacity/4;          // Increase capacity by 25%
 
-      if(!(psTemp = realloc(pS, capacity))) return 1;
+      if(!(psTemp = realloc(pS, capacity * sizeof(char*)))) return 1;
 
       pS = psTemp;
     }


### PR DESCRIPTION
In the call to `realloc()` in 7.14 multiplication with `sizeof(char*)` was forgotten leading to a core dump after entering the 7th line.